### PR TITLE
feat: Drop support for Safari 6 & 7

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,8 @@
 module.exports = [
   '> 1%',
-  'Last 2 versions',
   'IE >= 10',
   'Edge >= 13',
-  'Safari >= 6',
-  'iOS >= 6',
+  'Safari >= 8',
+  'iOS >= 8',
   'Samsung >= 4'
 ];

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@commitlint/cli": "^6.1.2",
     "browserslist": "^4.0.0",
+    "commitizen": "^3.0.5",
     "commitlint-config-seek": "^1.0.0",
     "cz-conventional-changelog": "^2.1.0",
     "eslint": "^4.18.1",


### PR DESCRIPTION
Also stop using last two versions. See https://jamie.build/last-2-versions

BREAKING CHANGE: Major policy update