### PR TITLE
Update supported browsers to reflect current browser policy

### DIFF
--- a/.changeset/forty-colts-stare.md
+++ b/.changeset/forty-colts-stare.md
@@ -1,5 +1,5 @@
 ---
-'browserslist-config-seek': minor
+'browserslist-config-seek': major
 ---
 
 Update supported browsers

--- a/.changeset/forty-colts-stare.md
+++ b/.changeset/forty-colts-stare.md
@@ -1,0 +1,5 @@
+---
+'browserslist-config-seek': minor
+---
+
+Update supported browsers

--- a/.changeset/forty-colts-stare.md
+++ b/.changeset/forty-colts-stare.md
@@ -2,4 +2,12 @@
 'browserslist-config-seek': major
 ---
 
-Update supported browsers
+Update supported browsers to the following:
+
+| Browser          | Oldest supported version |
+| ---------------- | ------------------------ |
+| Chrome           | 84                       |
+| Edge             | 84                       |
+| Safari           | 14.1                     |
+| Firefox          | 63                       |
+| Samsung Internet | 14.0                     |

--- a/index.js
+++ b/index.js
@@ -1,1 +1,8 @@
-module.exports = ['Edge >= 16', 'Safari >= 9.1', 'iOS >= 9.3', 'Samsung >= 5'];
+module.exports = [
+  'Chrome >= 84',
+  'Edge >= 84',
+  'Safari >= 14.1',
+  'iOS >= 14.1',
+  'Firefox >= 63',
+  'Samsung >= 14',
+];


### PR DESCRIPTION
Update supported browsers to the lowest available that support [CSS gap for Flex Layout](https://caniuse.com/?search=CSS%20property%3A%20gap%3A%20Supported%20in%20Flex%20Layout) in line with new SEEK policy.

Explicitly specify all browsers that SEEK supports (adding Chrome, Firefox and Samsung)