### PR TITLE
Add type definition for config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@1.5.0/schema.json",
+  "$schema": "https://unpkg.com/@changesets/config@3.0.3/schema.json",
   "changelog": [
     "@changesets/changelog-github",
     { "repo": "seek-oss/browserslist-config-seek" }
@@ -7,5 +7,8 @@
   "commit": false,
   "linked": [],
   "access": "public",
-  "baseBranch": "master"
+  "baseBranch": "master",
+  "snapshot": {
+    "useCalculatedVersion": true
+  }
 }

--- a/.changeset/pretty-files-compete.md
+++ b/.changeset/pretty-files-compete.md
@@ -1,0 +1,5 @@
+---
+'browserslist-config-seek': minor
+---
+
+Add type definition for default export

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,1 +1,1 @@
-module.exports = require('eslint-config-seek');
+module.exports = require('eslint-config-seek/base');

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2 @@
+declare const browserslistConfigSeek: string[];
+export default browserslistConfigSeek;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.1",
+    "@tsconfig/node20": "^20.1.4",
     "browserslist": "^4.23.0",
     "eslint": "^9.13.0",
     "eslint-config-seek": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "pnpm run '/lint:.*/'",
     "lint:eslint": "eslint .",
     "lint:prettier": "prettier . --list-different",
+    "lint:tsc": "tsc",
     "release": "changeset publish",
     "version": "changeset version"
   },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.1.0",
   "description": "Shareable Browserslist config for SEEK",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "node test.js",
     "format": "pnpm run '/format:.*/'",
@@ -15,7 +16,8 @@
     "version": "changeset version"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.27.1
         version: 2.27.1
+      '@tsconfig/node20':
+        specifier: ^20.1.4
+        version: 20.1.4
       browserslist:
         specifier: ^4.23.0
         version: 4.23.0
@@ -181,6 +184,9 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@tsconfig/node20@20.1.4':
+    resolution: {integrity: sha512-sqgsT69YFeLWf5NtJ4Xq/xAF8p4ZQHlmGW74Nu2tD4+g5fAsposc4ZfaaPixVu4y01BEiDCWLRDCvDM5JOsRxg==}
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -1934,6 +1940,8 @@ snapshots:
       fastq: 1.11.0
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@tsconfig/node20@20.1.4': {}
 
   '@types/estree@1.0.6': {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@tsconfig/node20/tsconfig.json"
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,7 @@
 {
-  "extends": "@tsconfig/node20/tsconfig.json"
+  "extends": "@tsconfig/node20/tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "files": ["index.d.ts"]
 }


### PR DESCRIPTION
- Added type definition for the browserslist config
- Swapped to `eslint-config-seek/base` as this is not a react project
- Added a `tsconfig` to make `eslint` happy
- Set up a `tsc` lint step to check the type definitions
- Set `useCalculatedVersion: true` in the changeset config

Have tested in `sku` with `pnpm link`, but would like to test a snapshot too #46.