### PR TITLE
Include `ChomeAndroid` in supported browsers

### DIFF
--- a/.changeset/eighty-nails-invite.md
+++ b/.changeset/eighty-nails-invite.md
@@ -1,0 +1,5 @@
+---
+'browserslist-config-seek': patch
+---
+
+Include `ChromeAndroid` in supported browsers, matching the `Chrome` version

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 module.exports = [
   'Chrome >= 89',
+  'ChromeAndroid >= 89',
   'Edge >= 89',
   'Safari >= 15.0',
   'iOS >= 15.0',


### PR DESCRIPTION
`ChromeAndroid` browsers match the Chrome desktop Chromium versions, so adding a separate policy here will have no code impact on users of this package. Making this change so that the coverage on Browserslist more accurately reflects our actual coverage (given `ChromeAndroid` has a substantial user base). Adding any additional browsers does not seem worth the trouble

* [Without `ChromeAndroid`](https://browsersl.ist/#q=Chrome+%3E%3D+89%2C+Edge+%3E%3D+89%2C+Safari+%3E%3D+15.0%2C+iOS+%3E%3D+15.0%2C+Firefox+%3E%3D+89%2C+Samsung+%3E%3D+15) - 46.9 %
* [With `ChromeAndroid`](https://browsersl.ist/#q=Chrome+%3E%3D+89%2C+ChromeAndroid+%3E%3D+89%2C+Edge+%3E%3D+89%2C+Safari+%3E%3D+15.0%2C+iOS+%3E%3D+15.0%2C+Firefox+%3E%3D+89%2C+Samsung+%3E%3D+15%2C+) - 92.3 %

~~**NB**: Not publishing a new version with this update, as it does not seem worth the noise given no expected code impact. Adding this now so that it gets rolled into future updates of the browser support policy~~
