### PR TITLE
Fix type declarations

### DIFF
--- a/.changeset/twenty-flies-invite.md
+++ b/.changeset/twenty-flies-invite.md
@@ -1,0 +1,5 @@
+---
+'browserslist-config-seek': patch
+---
+
+Fix type declarations

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,2 @@
 declare const browserslistConfigSeek: string[];
-export default browserslistConfigSeek;
+export = browserslistConfigSeek;


### PR DESCRIPTION
The package is distributed as CJS but the current types aren't in [the CJS type format](https://www.typescriptlang.org/docs/handbook/modules/reference.html#export--and-import--require).